### PR TITLE
Made makeodc.bat, make_asm.bat bail if build tools could not run.

### DIFF
--- a/src/ASM/MAKE_ASM.BAT
+++ b/src/ASM/MAKE_ASM.BAT
@@ -1,21 +1,34 @@
 echo off
+del my_asm88.exe >nul
+del chain.o >nul
 asm88 chain
 if errorlevel 1 goto stop
+if not exist chain.o goto stop
 
+del asm88.o >nul
 c88 asm88 %1
 if errorlevel 1 goto stop
+if not exist asm88.o goto stop
 
+del asm2.o >nul
 c88 asm2 %1
 if errorlevel 1 goto stop
+if not exist asm2.o goto stop
 
+del asm3.o >nul
 c88 asm3 %1
 if errorlevel 2 goto stop
+if not exist asm3.o goto stop
 
+del asm4.o >nul
 c88 asm4 %1
 if errorlevel 1 goto stop
+if not exist asm4.o goto stop
 
+del asm5.o >nul
 c88 asm5 %1
 if errorlevel 1 goto stop
+if not exist asm5.o goto stop
 
 if .%1.==.c. goto generate_chk
 

--- a/src/MAKEODC.BAT
+++ b/src/MAKEODC.BAT
@@ -6,6 +6,7 @@ echo Building asm88.exe
 
 cd asm
 call make_asm.bat
+if not exist my_asm88.exe goto stop
 copy my_asm88.exe ..\bin\asm88.exe
 cd ..
 
@@ -13,6 +14,7 @@ echo Building bind.exe
 
 cd bind
 call makebind.bat
+if not exist my_bind.exe goto stop
 copy my_bind.exe ..\bin\bind.exe
 cd ..
 
@@ -20,6 +22,7 @@ echo Building c88.exe
 
 cd c
 call make_c88.bat
+if not exist my_c88.exe goto stop
 copy my_c88.exe ..\bin\c88.exe
 cd ..
 
@@ -27,6 +30,7 @@ echo Building d88.exe
 
 cd d
 call make_d88.bat
+if not exist my_d88.exe goto stop
 copy my_d88.exe ..\bin\d88.exe
 cd ..
 
@@ -34,6 +38,7 @@ echo Building gen.exe
 
 cd gen
 call make_gen.bat
+if not exist my_gen.exe goto stop
 copy my_gen.exe ..\bin\gen.exe
 cd ..
 
@@ -41,6 +46,8 @@ echo Building lib88.exe
 
 cd lib88
 call make_l88.bat
+if not exist my_lib88.exe goto stop
+if not exist mysquish.exe goto stop
 copy my_lib88.exe ..\bin\lib88.exe
 copy mysquish.exe ..\bin\squish.exe
 cd ..
@@ -49,6 +56,7 @@ echo Building nbind.exe
 
 cd nbind
 call make_nb.bat
+if not exist mynbind.exe goto stop
 copy mynbind.exe ..\bin\nbind.exe
 cd ..
 
@@ -56,6 +64,8 @@ echo Building others
 
 cd other
 call other.bat
+if not exist toobj.exe goto stop
+if not exist dumpobj.exe goto stop
 copy toobj.exe ..\bin\toobj.exe
 copy dumpobj.exe ..\bin\dumpobj.exe
 cd ..
@@ -64,6 +74,7 @@ echo Building see.exe
 
 cd see
 call make.bat
+if not exist s.exe goto stop
 copy s.exe ..\bin\see.exe
 cd ..
 
@@ -79,6 +90,7 @@ echo Building more tools
 cd src
 c88 cb
 bind cb
+if not exist cb.exe goto stop
 copy cb.exe ..\bin\cbcheck.exe
 cd ..
 
@@ -106,3 +118,10 @@ cd ..
 echo Build complete.
 echo All files should no reside in bin directory.
 
+goto ok
+
+:stop
+
+cd ..
+
+:ok


### PR DESCRIPTION
Invoking e.g. `asm88.exe` might not set the `errorlevel` correctly, if for some reason `asm88.exe` could not run in the first place.