### PR TITLE
Fix for issue #5 (Fix generation of i8 constants in direct-compiling mode)

### DIFF
--- a/src/GEN/GEN6.C
+++ b/src/GEN/GEN6.C
@@ -1423,6 +1423,6 @@ dummyw(wrd)
 realtype(vtype)
 	int vtype[]; {
 
-	if (vtype[VT] == CCHAR) return CCHAR;
+	if (vtype[VT] == CCHAR || vtype[VT] == CSCHAR) return CCHAR;
 	return CINT;
 	}


### PR DESCRIPTION
Erroneous code was being generated because "signed char" was not special-cased to 8 bits like "char" is.  This PR adds that special-case.